### PR TITLE
Convert gender string to lowercase

### DIFF
--- a/js/spniBehaviour.js
+++ b/js/spniBehaviour.js
@@ -117,7 +117,7 @@ function loadBehaviour (folder, callFunction, slot) {
             var first = $(xml).find('first').text();
             var last = $(xml).find('last').text();
             var label = $(xml).find('label').text();
-            var gender = $(xml).find('gender').text();
+            var gender = $(xml).find('gender').text().trim().toLowerCase(); //convert everything to lowercase, for comparison to the strings "male" and "female"
             var size = $(xml).find('size').text();
             var timer = $(xml).find('timer').text();
             


### PR DESCRIPTION
When reading a character from XML, convert the "gender" value to lowercase.

This means it will properly compare to the strings "male" and "female" in the code, even when the author uses upper-case letters.
