### PR TITLE
Change to meta.xml for Piper

### DIFF
--- a/opponents/piper/meta.xml
+++ b/opponents/piper/meta.xml
@@ -8,7 +8,7 @@
     <gender>female</gender>
     <height>5'5"</height>
     <from>Fallout 4</from>
-    <writer>Spicy_Harambe &amp; Throwaway10671</writer>
+    <writer>Spicy_Harambe/Throwaway10671</writer>
     <artist>Spicy_Harambe</artist>
     <description>Piper is the lead reporter for Publick Occurences, located in Diamond City.</description>
 </opponent>


### PR DESCRIPTION
Removed ampersand and replaced with forward slash so both names can appear for writer credits.