### PR TITLE
Recover lost behaviour dialogue

### DIFF
--- a/opponents/harley/behaviour.xml
+++ b/opponents/harley/behaviour.xml
@@ -59,7 +59,7 @@
                 <state img="0-smug.png">That's it? What a joke!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="0-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="0-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="0-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -98,7 +98,7 @@
                 <state img="0-horny.png">I like what you're selling, lady!</state>
             </case>
             <case tag="male_must_strip">
-                <state img="0-smug.png">HA! ya lose, chump!</state>
+                <state img="0-smug.png">HA! Ya lose, chump!</state>
             </case>
             <case tag="female_must_masturbate">
                 <state img="0-interested.png">Ya look all red, ya sure you're gonna be fine?</state>
@@ -137,7 +137,7 @@
                 <state img="0-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="0-shocked.png">That looked.. fun.</state>
+                <state img="0-shocked.png">That looked... fun.</state>
                 <state img="0-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="0-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -183,7 +183,7 @@
                 <state img="0-sad.png">I guess there always have to be someone who go first...</state>
             </case>
             <case tag="stripping">
-                <state img="0-strip.png">Here goes my ~clothing~...</state>
+                <state img="0-strip.png">Here go my boots...</state>
             </case>
             <case tag="must_strip_winning">
                 <state img="0-loss.png">Do I really have to? Winning was sort of nice.</state>
@@ -208,7 +208,7 @@
                 <state img="1-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="1-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="1-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="1-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -221,7 +221,7 @@
                 <state img="1-smug.png">Well fine, I'll make ya strip more later!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="1-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="1-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="1-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -260,7 +260,7 @@
                 <state img="1-shocked.png">W-Wow, they're so big... I'm not jealous!</state>
             </case>
             <case tag="male_must_strip">
-                <state img="1-smug.png">Do it ~name~!</state>
+                <state img="1-smug.png">Do it, ~name~!</state>
             </case>
             <case tag="female_must_masturbate">
                 <state img="1-interested.png">Ya look all red, ya sure you're gonna be fine?</state>
@@ -300,7 +300,7 @@
                 <state img="1-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="1-shocked.png">That looked.. fun.</state>
+                <state img="1-shocked.png">That looked... fun.</state>
                 <state img="1-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="1-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -339,7 +339,7 @@
                 <state img="1-excited.png">Hoped ya enjoyed the show! I ain't gonna lose again!</state>
             </case>
             <case tag="must_strip_normal">
-                <state img="1-loss.png">I guess my ~clothing~ are next...</state>
+                <state img="1-loss.png">I guess my sleeves are next...</state>
             </case>
             <case tag="must_strip_losing">
                 <state img="1-angry.png">I don't like this steak!</state>
@@ -354,7 +354,7 @@
 
         <stage id="2">
             <case tag="female_must_strip">
-                <state img="2-excited.png">Lose the ~clothing~! Yeah!</state>
+                <state img="2-excited.png">Lose your clothes! Yeah!</state>
             </case>
             <case tag="male_chest_will_be_visible">
                 <state img="2-excited.png">Shirt off, cowboy!</state>
@@ -370,7 +370,7 @@
                 <state img="2-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="2-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="2-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="2-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -383,7 +383,7 @@
                 <state img="2-smug.png">Well fine, I'll make ya strip more later!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="2-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="2-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="2-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -422,7 +422,7 @@
                 <state img="2-shocked.png">W-Wow, they're so big... I'm not jealous!</state>
             </case>
             <case tag="male_must_strip">
-                <state img="2-excited.png">ya better not disappoint me, ~name~!</state>
+                <state img="2-excited.png">Ya better not disappoint me, ~name~!</state>
             </case>
             <case tag="female_must_masturbate">
                 <state img="2-interested.png">Ya look all red, ya sure you're gonna be fine?</state>
@@ -462,7 +462,7 @@
                 <state img="2-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="2-shocked.png">That looked.. fun.</state>
+                <state img="2-shocked.png">That looked... fun.</state>
                 <state img="2-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="2-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -501,7 +501,7 @@
                 <state img="2-stripped.png">There! Now let's try to get ya to lose.</state>
             </case>
             <case tag="must_strip_normal">
-                <state img="2-loss.png">Hpfm.</state>
+                <state img="2-loss.png">Hmph.</state>
             </case>
             <case tag="must_strip_losing">
                 <state img="2-shocked.png">S-So soon? What's going on?</state>
@@ -532,7 +532,7 @@
                 <state img="3-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="3-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="3-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="3-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -545,7 +545,7 @@
                 <state img="3-smug.png">Well fine, I'll make ya strip more later!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="3-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="3-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="3-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -624,7 +624,7 @@
                 <state img="3-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="3-shocked.png">That looked.. fun.</state>
+                <state img="3-shocked.png">That looked... fun.</state>
                 <state img="3-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="3-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -647,6 +647,7 @@
             </case>
             <case tag="good_hand">
                 <state img="3-happy.png">Yes! This ~clothing~ is staying on!</state>
+                <state img="3-happy.png">Yes! You're not gonna get me outta these clothes THAT easily, puddin'!</state>
             </case>
             <case tag="okay_hand">
                 <state img="3-calm.png">I hope I get a better hand next!</state>
@@ -660,7 +661,7 @@
                 <state img="3-angry.png">Wait a minute... Is this game rigged or something?</state>
             </case>
             <case tag="stripped">
-                <state img="3-stripped.png">Huh, blood? Don't worry about it, pudding.</state>
+                <state img="3-stripped.png">Huh, blood? Don't worry about it, puddin'.</state>
             </case>
             <case tag="must_strip_normal">
                 <state img="3-loss.png">Hm. Why can't I catch a break?</state>
@@ -694,7 +695,7 @@
                 <state img="4-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="4-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="4-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="4-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -707,7 +708,7 @@
                 <state img="4-smug.png">Well fine, I'll make ya strip more later!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="4-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="4-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="4-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -716,7 +717,7 @@
                 <state img="4-horny.png">That's why I wanted to play this game!</state>
             </case>
             <case tag="female_human_must_strip">
-                <state img="4-horny.png">ya remind me of Red, right abut now...</state>
+                <state img="4-horny.png">Ya remind me of Red, right abut now...</state>
             </case>
             <case tag="female_crotch_is_visible">
                 <state img="4-horny.png">Nice pussy, ~name~...</state>
@@ -786,7 +787,7 @@
                 <state img="4-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="4-shocked.png">That looked.. fun.</state>
+                <state img="4-shocked.png">That looked... fun.</state>
                 <state img="4-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="4-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -856,7 +857,7 @@
                 <state img="5-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="5-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="5-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="5-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -869,7 +870,7 @@
                 <state img="5-smug.png">Well fine, I'll make ya strip more later!</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="5-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="5-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="5-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -948,7 +949,7 @@
                 <state img="5-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="5-shocked.png">That looked.. fun.</state>
+                <state img="5-shocked.png">That looked... fun.</state>
                 <state img="5-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="5-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -1011,7 +1012,7 @@
                 <state img="6-excited.png">Finally! Remove it, quick!</state>
             </case>
             <case tag="male_medium_crotch_is_visible">
-                <state img="6-horny.png">ya don't disappoint, do ya?</state>
+                <state img="6-horny.png">Ya don't disappoint, do ya?</state>
             </case>
             <case tag="female_removed_major">
                 <state img="6-interested.png">And it's... just like I hoped, heh-heh.</state>
@@ -1027,10 +1028,9 @@
             </case>
             <case tag="male_removed_accessory">
                 <state img="6-sad.png">Meanwhile, I'm here in my underwear...</state>
-                <state img="6-sad.png">Meanwhile, I'm here half naked...</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="6-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="6-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="6-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -1053,7 +1053,6 @@
                 <state img="6-excited.png">Own that shit. Own it!</state>
             </case>
             <case tag="female_removed_accessory">
-                <state img="6-shocked.png">Oh come on! I was looking forward to it!</state>
                 <state img="6-shocked.png">Oh come on! I was looking forward to it!</state>
             </case>
             <case tag="male_removed_major">
@@ -1085,7 +1084,6 @@
             </case>
             <case tag="male_removing_accessory">
                 <state img="6-angry.png">WHAT?! Ya chump! How do ya still have that!</state>
-                <state img="6-angry.png">WHAT?! Ya chump! How do ya still have that!</state>
             </case>
             <case tag="male_finished_masturbating">
                 <state img="6-excited.png">All done? That was a nice show, handsome!</state>
@@ -1099,8 +1097,7 @@
                 <state img="6-horny.png">So round and bouncy...</state>
             </case>
             <case tag="female_removing_accessory">
-                <state img="6-shocked.png">ya still have that?!</state>
-                <state img="6-shocked.png">ya still have that?!</state>
+                <state img="6-shocked.png">Ya still have that?!</state>
             </case>
             <case tag="game_over_victory">
                 <state img="6-excited.png">That was close!</state>
@@ -1112,7 +1109,7 @@
                 <state img="6-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="6-shocked.png">That looked.. fun.</state>
+                <state img="6-shocked.png">That looked... fun.</state>
                 <state img="6-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="6-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -1182,7 +1179,7 @@
                 <state img="7-interested.png">And it's... just like I hoped, heh-heh.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="7-shocked.png">It's so much bigger than Miste... *ahem* It's big is what I'm saying.</state>
+                <state img="7-shocked.png">It's so much bigger than Mistah... *ahem* It's big is what I'm saying.</state>
                 <state img="7-shocked.png">If you try'na scare me, it won't work!</state>
             </case>
             <case tag="female_crotch_will_be_visible">
@@ -1192,10 +1189,10 @@
                 <state img="7-happy.png">And one more down!</state>
             </case>
             <case tag="male_removed_accessory">
-                <state img="7-smug.png">Well fine, I'll make ya strip more later!</state>
+                <state img="7-sad.png">Meanwhile, I'm here half naked...</state>
             </case>
             <case tag="male_must_masturbate">
-                <state img="7-interested.png">No more clothes to strip of, cowboy? ya know what that means...</state>
+                <state img="7-interested.png">No more clothes to strip off, cowboy? Ya know what that means...</state>
                 <state img="7-horny.png">You're really going to do it? You're such a gracious loser ~name~!</state>
             </case>
             <case tag="female_masturbating">
@@ -1218,7 +1215,7 @@
                 <state img="7-excited.png">Own that shit. Own it!</state>
             </case>
             <case tag="female_removed_accessory">
-                <state img="7-calm.png">Dealer hit me, I'm getting bored.</state>
+                <state img="7-shocked.png">Oh come on! I was looking forward to it!</state>
             </case>
             <case tag="male_removed_major">
                 <state img="7-smug.png">HA! Look at you!</state>
@@ -1248,7 +1245,7 @@
                 <state img="7-smug.png">Look at this guy...</state>
             </case>
             <case tag="male_removing_accessory">
-                <state img="7-sad.png">Just that? Don't ya want to make me smile?</state>
+                <state img="7-angry.png">WHAT?! Ya chump! How do ya still have that!</state>
             </case>
             <case tag="male_finished_masturbating">
                 <state img="7-excited.png">All done? That was a nice show, handsome!</state>
@@ -1262,10 +1259,10 @@
                 <state img="7-interested.png">This reminds me of Ivy... Why isn't she playing?</state>
             </case>
             <case tag="female_removing_accessory">
-                <state img="7-sad.png">Just that? You're lame!</state>
+                <state img="7-shocked.png">Ya still have that?!</state>
             </case>
             <case tag="game_over_victory">
-                <state img="7-smug.png">ya lose, suckers!</state>
+                <state img="7-smug.png">Ya lose, suckers!</state>
             </case>
             <case tag="female_removing_major">
                 <state img="7-interested.png">Now ya got me hyped up!</state>
@@ -1274,7 +1271,7 @@
                 <state img="7-excited.png">This is a nice preview...</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="7-shocked.png">That looked.. fun.</state>
+                <state img="7-shocked.png">That looked... fun.</state>
                 <state img="7-horny.png">I'll cherry this memory all my life, ~name~!</state>
                 <state img="7-horny.png">All good things have to end, I guess...</state>
             </case>
@@ -1313,7 +1310,7 @@
                 <state img="7-stripped.png">There! Look at it all ya want, ya perverts!</state>
             </case>
             <case tag="must_strip_normal">
-                <state img="7-loss.png">You're all looking at me with such.. lust.</state>
+                <state img="7-loss.png">You're all looking at me with such... lust.</state>
             </case>
             <case tag="must_strip_losing">
                 <state img="7-loss.png">G-guess you're all laughing at me...</state>
@@ -1365,7 +1362,7 @@
                 <state img="8-excited.png">Don't mind me, just staring at ya...</state>
             </case>
             <case tag="female_crotch_is_visible">
-                <state img="8-horny.png">ya look wet ~name~. Got anything to confess?</state>
+                <state img="8-horny.png">Ya look wet ~name~. Got anything to confess?</state>
             </case>
             <case tag="female_start_masturbating">
                 <state img="8-horny.png">G-Going right at it, huh?</state>
@@ -1381,7 +1378,7 @@
                 <state img="8-smug.png">HA! Look at you!</state>
             </case>
             <case tag="male_start_masturbating">
-                <state img="8-horny.png">ya can look at me while ya do it, I don't mind...</state>
+                <state img="8-horny.png">Ya can look at me while ya do it, I don't mind...</state>
             </case>
             <case tag="male_chest_is_visible">
                 <state img="8-horny.png">Nice pecs ~name~. Mind if I touch them?</state>
@@ -1426,7 +1423,7 @@
                 <state img="8-excited.png">At least you're removing something nice!</state>
             </case>
             <case tag="female_finished_masturbating">
-                <state img="8-horny.png">ya made a real mess, didn't ya ~name~?</state>
+                <state img="8-horny.png">Ya made a real mess, didn't ya ~name~?</state>
             </case>
             <case tag="female_chest_will_be_visible">
                 <state img="8-interested.png">Show them to me, ~name~!</state>
@@ -1456,7 +1453,7 @@
                 <state img="8-horny.png">Okay Harl, don't be embarrassed...</state>
             </case>
             <case tag="start_masturbating">
-                <state img="8-starting.png">Just.. Just never talk to this to anyone.</state>
+                <state img="8-starting.png">Just... Just never talk to this to anyone.</state>
             </case>
             <case tag="stripped">
                 <state img="8-stripped.png">...</state>
@@ -1465,7 +1462,7 @@
                 <state img="8-stunned.png">I-I'm going first? Fine...</state>
             </case>
             <case tag="must_masturbate">
-                <state img="8-loss.png">And Harley joins the losers!</state>
+                <state img="8-angry.png">And Harley joins the losers!</state>
             </case>
         </stage>
 
@@ -1554,7 +1551,7 @@
                 <state img="9-horny.png">They're so cute. I just want to lick them...</state>
             </case>
             <case tag="female_medium_chest_is_visible">
-                <state img="9-horny.png">I really to feel them...</state>
+                <state img="9-horny.png">I really want to feel them...</state>
             </case>
             <case tag="female_removing_accessory">
                 <state img="9-sad.png">~name~ y-you're so cruel...</state>
@@ -1584,13 +1581,13 @@
                 <state img="9-interested.png">Y-Yes! Please ~name~!</state>
             </case>
             <case tag="masturbating">
-                <state img="9-calm.png">Mmm..This is nice.</state>
+                <state img="9-calm.png">Mmm... This is nice.</state>
             </case>
             <case tag="finishing_masturbating">
                 <state img="9-finishing.png">FUCK YES!</state>
             </case>
             <case tag="heavy_masturbating">
-                <state img="9-heavy.png">Yeah.. Hmmm.. Just like that...</state>
+                <state img="9-heavy.png">Yeah... Hmmm... Just like that...</state>
             </case>
         </stage>
 
@@ -1662,7 +1659,7 @@
                 <state img="10-interested.png">Your turn to shine!</state>
             </case>
             <case tag="male_human_must_strip">
-                <state img="10-stunned.png">ya still got clothes?</state>
+                <state img="10-stunned.png">Ya still got clothes?</state>
             </case>
             <case tag="male_small_crotch_is_visible">
                 <state img="10-horny.png">Better late than never, though!</state>
@@ -1680,13 +1677,13 @@
                 <state img="10-horny.png">Christmas is early I guess!</state>
             </case>
             <case tag="female_removing_accessory">
-                <state img="10-shocked.png">ya still have that? Guess you're really tough ~name~.</state>
+                <state img="10-shocked.png">Ya still have that? Guess you're really tough ~name~.</state>
             </case>
             <case tag="game_over_victory">
                 <state img="10-stunned.png"> You're joking? I don't get it.</state>
             </case>
             <case tag="female_removing_major">
-                <state img="10-interested.png">ya remind of Red...</state>
+                <state img="10-interested.png">Ya remind of Red...</state>
             </case>
             <case tag="male_removing_minor">
                 <state img="10-calm.png">You're a bit behind but it's starting to be interesting.</state>

--- a/opponents/harley/harley.txt
+++ b/opponents/harley/harley.txt
@@ -77,10 +77,10 @@ stripped=sad,Just forewarning you, I'm known for being quite vexing...
 #these only come up in the relevant stages, so ya don't need to include the stage numbers here
 #just remember which stage is which when ya make the images
 must_masturbate_first=stunned,I-I'm going first? Fine...
-must_masturbate=loss,And Harley joins the losers!
-start_masturbating=starting,Just.. Just never talk to this to anyone.
-masturbating=calm,Mmm..This is nice.
-heavy_masturbating=heavy,Yeah.. Hmmm.. Just like that...
+must_masturbate=angry,And Harley joins the losers!
+start_masturbating=starting,Just... Just never talk to this to anyone.
+masturbating=calm,Mmm... This is nice.
+heavy_masturbating=heavy,Yeah... Hmmm... Just like that...
 finishing_masturbating=finishing,FUCK YES!
 finished_masturbating=finished,Wow, that was a fun time!
 #I don't think this line is actually used by the game.
@@ -110,11 +110,11 @@ male_small_crotch_is_visible=excited,Nothing to be ashamed of, puddin'. It's sti
 male_small_crotch_is_visible=smug,Look at this guy...
 male_medium_crotch_is_visible=horny,Harley wants!
 male_medium_crotch_is_visible=excited,I love this guy!
-male_large_crotch_is_visible=shocked,It's so much bigger than Miste... *ahem* It's big is what I'm saying.
+male_large_crotch_is_visible=shocked,It's so much bigger than Mistah... *ahem* It's big is what I'm saying.
 male_large_crotch_is_visible=shocked,If you try'na scare me, it won't work!
 
 #male masturbation default
-male_must_masturbate=interested,No more clothes to strip of, cowboy? ya know what that means...
+male_must_masturbate=interested,No more clothes to strip off, cowboy? Ya know what that means...
 male_start_masturbating=horny,Try to last a few rounds so I can enjoy the view, puddin'.
 male_masturbating=horny,The way it moves is driving me... crazy. Ha ha!
 male_finished_masturbating=excited,All done? That was a nice show, handsome!
@@ -145,7 +145,7 @@ female_crotch_is_visible=horny,Nice pussy, ~name~...
 female_must_masturbate=interested,Ya look all red, ya sure you're gonna be fine?
 female_start_masturbating=horny,Try to set the record, missie!
 female_masturbating=horny,Yes ~name~, keep going ha ha!
-female_finished_masturbating=shocked,That looked.. fun.
+female_finished_masturbating=shocked,That looked... fun.
 
 
 #These responses are stage specific.
@@ -168,22 +168,22 @@ female_finished_masturbating=shocked,That looked.. fun.
 0-must_strip_winning=loss,Do I really have to? Winning was sort of nice.
 0-must_strip_normal=loss,Wanna play strip the clown?
 0-must_strip_losing=sad,I guess there always have to be someone who go first...
-0-stripping=strip,Here goes my ~clothing~...
+0-stripping=strip,Here go my boots...
 1-stripped=excited,Hoped ya enjoyed the show! I ain't gonna lose again!
 
 #losing second item of clothing
 1-must_strip_winning=smug,I kinda felt bad for all of ya, anyway!
-1-must_strip_normal=loss,I guess my ~clothing~ are next...
+1-must_strip_normal=loss,I guess my sleeves are next...
 1-must_strip_losing=angry,I don't like this steak!
 1-stripping=strip,I liked these...
 2-stripped=stripped,There! Now let's try to get ya to lose.
 
 #losing third item of clothing
 2-must_strip_winning=smug,Considering your states, I don't mind losing!
-2-must_strip_normal=loss,Hpfm.
+2-must_strip_normal=loss,Hmph.
 2-must_strip_losing=shocked,S-So soon? What's going on?
 2-stripping=strip,I guess it'd be a shame to get blood all over my nice new ~clothing~. 
-3-stripped=stripped,Huh, blood? Don't worry about it, pudding.
+3-stripped=stripped,Huh, blood? Don't worry about it, puddin'.
 
 #losing fourth item of clothing
 3-must_strip_winning=excited,So ya want me to go down to your level, don't cha?
@@ -215,7 +215,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 
 #losing eighth item of clothing (if the character has the maximum eight pieces of clothing, they're naked now. Otherwise, they got naked earlier.)
 7-must_strip_winning=loss,Heh-heh, so I'm gonna have to strip...
-7-must_strip_normal=loss,You're all looking at me with such.. lust.
+7-must_strip_normal=loss,You're all looking at me with such... lust.
 7-must_strip_losing=loss,G-guess you're all laughing at me...
 7-stripping=strip,Can't Bats save me now?
 8-stripped=stripped,...
@@ -228,7 +228,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 4-game_over_victory=excited,Don't have as many clothes as I wish, but still. A win is a win.
 5-game_over_victory=excited,HA! Winner winner chicken dinner!
 6-game_over_victory=excited,That was close!
-7-game_over_victory=smug,ya lose, suckers!
+7-game_over_victory=smug,Ya lose, suckers!
 -3-game_over_victory=happy,And I was so looking for that forfeit. Guess I'll have to do it back at home...
 -2-game_over_victory=stunned, I-I won? How?
 -1-game_over_victory=stunned, You're joking? I don't get it.
@@ -251,6 +251,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 
 #lost three items
 3-good_hand=happy,Yes! This ~clothing~ is staying on!
+3-good_hand=happy,Yes! You're not gonna get me outta these clothes THAT easily, puddin'!
 3-okay_hand=calm,I hope I get a better hand next!
 3-bad_hand=angry,Wait a minute... Is this game rigged or something?
 
@@ -285,21 +286,21 @@ female_finished_masturbating=shocked,That looked.. fun.
 ##other player must strip specific
 #fully clothed
 0-male_human_must_strip=excited,What's going on? You're getting all red over there...
-0-male_must_strip=smug,HA! ya lose, chump!
+0-male_must_strip=smug,HA! Ya lose, chump!
 0-female_human_must_strip=excited,Go on, I'm watching...
 0-female_must_strip=smug,Bad luck, sucker!
 
 #lost 1 item
 1-male_human_must_strip=excited,C'mon ~name~, don't make me wait! 
-1-male_must_strip=smug,Do it ~name~!
+1-male_must_strip=smug,Do it, ~name~!
 1-female_human_must_strip=excited,Isn't this exciting ~name~? ya get to strip and I get to watch!
 1-female_must_strip=smug,That's right! And don't forget to smile!
 
 #lost 2 items
 2-male_human_must_strip=happy,Hey everybody, ~name~ is stripping! 
-2-male_must_strip=excited,ya better not disappoint me, ~name~!
+2-male_must_strip=excited,Ya better not disappoint me, ~name~!
 2-female_human_must_strip=smug,Looking better by the minute.
-2-female_must_strip=excited,Lose the ~clothing~! Yeah!
+2-female_must_strip=excited,Lose your clothes! Yeah!
 
 #lost 3 items
 3-male_human_must_strip=smug,This is a great game!
@@ -310,7 +311,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 #lost lost 4 items
 4-male_human_must_strip=smug,Go on ~name~! It's all in good fun!
 4-male_must_strip=excited,What a gentlemen! Stripping, so I don't!
-4-female_human_must_strip=horny,ya remind me of Red, right abut now...
+4-female_human_must_strip=horny,Ya remind me of Red, right abut now...
 4-female_must_strip=interested,Let everyone see what's underneath, ~name~!
 
 #lost 5 items
@@ -344,7 +345,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 -2-female_must_strip=interested,Don't worry ~name~, I won't bite. Much.
 
 #finished
--1-male_human_must_strip=stunned,ya still got clothes? 
+-1-male_human_must_strip=stunned,Ya still got clothes? 
 -1-male_must_strip=stunned,I could have used this before. Oh well, better late than never.
 -1-female_human_must_strip=excited,You're getting me pumped up again!
 -1-female_must_strip=excited,Watch out ~name~, or you'll be just like me...
@@ -389,14 +390,14 @@ female_finished_masturbating=shocked,That looked.. fun.
 #lost 6 items
 6-male_removing_accessory=angry,WHAT?! Ya chump! How do ya still have that!
 6-male_removed_accessory=sad,Meanwhile, I'm here in my underwear...
-6-female_removing_accessory=shocked,ya still have that?!
+6-female_removing_accessory=shocked,Ya still have that?!
 6-female_removed_accessory=shocked,Oh come on! I was looking forward to it!
 
 #lost 7 items
-6-male_removing_accessory=angry,WHAT?! Ya chump! How do ya still have that!
-6-male_removed_accessory=sad,Meanwhile, I'm here half naked...
-6-female_removing_accessory=shocked,ya still have that?!
-6-female_removed_accessory=shocked,Oh come on! I was looking forward to it!
+7-male_removing_accessory=angry,WHAT?! Ya chump! How do ya still have that!
+7-male_removed_accessory=sad,Meanwhile, I'm here half naked...
+7-female_removing_accessory=shocked,Ya still have that?!
+7-female_removed_accessory=shocked,Oh come on! I was looking forward to it!
 
 #nude
 -3-male_removing_accessory=angry,You're no fun! No fun at all!
@@ -413,7 +414,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 #finished
 -1-male_removing_accessory=sad,Wow can't believe I lost this fast...
 -1-male_removed_accessory=angry,Can't believe this...
--1-female_removing_accessory=shocked,ya still have that? Guess you're really tough ~name~.
+-1-female_removing_accessory=shocked,Ya still have that? Guess you're really tough ~name~.
 -1-female_removed_accessory=sad,I have to admit, I'm a bit disappointed...
 
 ##another character is removing minor clothing items
@@ -547,7 +548,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 #finished
 -1-male_removing_major=interested,Go on cowboy! Show me what ya got!
 -1-male_removed_major=interested,That's karma for you! And I don't mind it one bit...
--1-female_removing_major=interested,ya remind of Red...
+-1-female_removing_major=interested,Ya remind of Red...
 -1-female_removed_major=interested,Hmmm....
 
 ##another character is removing important clothes
@@ -647,7 +648,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 6-male_chest_is_visible=horny,This is so.. hot...
 6-male_crotch_will_be_visible=interested,You're really going to do it? Niiice...
 6-male_small_crotch_is_visible=horny,Nevermind the size, it's still looks yummy...
-6-male_medium_crotch_is_visible=horny,ya don't disappoint, do ya?
+6-male_medium_crotch_is_visible=horny,Ya don't disappoint, do ya?
 6-male_large_crotch_is_visible=stunned, T-This is so big... I wonder what it feels like...
 
 6-female_chest_will_be_visible=interested,Go slowly girl, I want to savor it...
@@ -686,7 +687,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 -3-female_medium_chest_is_visible=horny,Now we have to compare size, ~name~!
 -3-female_large_chest_is_visible=horny,S-So big!
 -3-female_crotch_will_be_visible=interested,Show me your goods!
--3-female_crotch_is_visible=horny,ya look wet ~name~. Got anything to confess?
+-3-female_crotch_is_visible=horny,Ya look wet ~name~. Got anything to confess?
 
 #masturbating
 -2-male_chest_will_be_visible=interested,F-Finally!
@@ -698,7 +699,7 @@ female_finished_masturbating=shocked,That looked.. fun.
 
 -2-female_chest_will_be_visible=interested,I don't mind taking a peek. Even if you're a girl.
 -2-female_small_chest_is_visible=horny,They're so cute. I just want to lick them...
--2-female_medium_chest_is_visible=horny,I really to feel them...
+-2-female_medium_chest_is_visible=horny,I really want to feel them...
 -2-female_large_chest_is_visible=horny,That's what I hoped for!
 -2-female_crotch_will_be_visible=interested,Guess I'm into girls as well...
 -2-female_crotch_will_be_visible=interested,Y-Yeah, take them off ~name~! Everyone wants ya to!
@@ -821,7 +822,7 @@ female_finished_masturbating=horny,All good things have to end, I guess...
 
 #nude
 -3-male_must_masturbate=excited,Mmm, this is hot, don't cha think?
--3-male_start_masturbating=horny,ya can look at me while ya do it, I don't mind...
+-3-male_start_masturbating=horny,Ya can look at me while ya do it, I don't mind...
 -3-male_masturbating=horny,Feeling good ~name~? I bet ya do...
 -3-male_masturbating=horny,Looking at ya go, I wouln't mind losing all of a sudden...
 -3-male_finished_masturbating=horny,W-Wow ya got some over me! I like it...
@@ -830,7 +831,7 @@ female_finished_masturbating=horny,All good things have to end, I guess...
 -3-female_start_masturbating=horny,G-Going right at it, huh?
 -3-female_masturbating=horny,Feeling good ~name~? I bet ya do...
 -3-female_masturbating=horny,Looking at me? You're interested, aren't ya? Heh-heh...
--3-female_finished_masturbating=horny,ya made a real mess, didn't ya ~name~?
+-3-female_finished_masturbating=horny,Ya made a real mess, didn't ya ~name~?
 
 #masturbating
 -2-male_must_masturbate=interested,Y..You're joining me?! This is great!

--- a/opponents/make_xml.py
+++ b/opponents/make_xml.py
@@ -453,7 +453,7 @@ def read_player_file(filename):
 					break
 
 			if (len(problem_character) == 0):
-				print "Unable to decode character %s in line %d: \"%s\"" % (c, line_number, line)
+				print "Unable to decode character %s in line %d: \"%s\"" % (problem_character, line_number, line)
 			else:
 				print "Unable to decode line \"%s\" in line %d: " % (line, line_number)
 

--- a/opponents/make_xml.py
+++ b/opponents/make_xml.py
@@ -438,13 +438,28 @@ def read_player_file(filename):
 		
 		#check for characters that can't be used
 		skip_line = False
-		for c in line:
-			try:
-				c.decode('utf-8')
-			except UnicodeDecodeError:
+		try:
+			# In utf-8, characters using umlauts are actually encoded as two separate characters
+            # so we need to try to decode the entire line instead of individual characters
+			line.decode('utf-8')
+		except UnicodeDecodeError:
+			# Find out which character
+			problem_character = ""
+			for c in line:
+				try:
+					c.decode('utf-8')
+				except UnicodeDecodeError:
+					problem_character = c
+					break
+
+			if (len(problem_character) == 0):
 				print "Unable to decode character %s in line %d: \"%s\"" % (c, line_number, line)
-				skip_line = True
-				break
+			else:
+				print "Unable to decode line \"%s\" in line %d: " % (line, line_number)
+
+			skip_line = True
+			break
+
 		if skip_line:
 			continue
 		

--- a/opponents/make_xml.py
+++ b/opponents/make_xml.py
@@ -440,7 +440,7 @@ def read_player_file(filename):
 		skip_line = False
 		try:
 			# In utf-8, characters using umlauts are actually encoded as two separate characters
-            # so we need to try to decode the entire line instead of individual characters
+			# so we need to try to decode the entire line instead of individual characters
 			line.decode('utf-8')
 		except UnicodeDecodeError:
 			# Find out which character
@@ -452,7 +452,7 @@ def read_player_file(filename):
 					problem_character = c
 					break
 
-			if (len(problem_character) == 0):
+			if (len(problem_character) > 0):
 				print "Unable to decode character %s in line %d: \"%s\"" % (problem_character, line_number, line)
 			else:
 				print "Unable to decode line \"%s\" in line %d: " % (line, line_number)

--- a/opponents/mercy/behaviour.txt
+++ b/opponents/mercy/behaviour.txt
@@ -597,6 +597,7 @@ female_crotch_is_visible=shocked,It is kind off hard to see from here, perhaps l
 -2-male_chest_is_visible=,
 -2-male_crotch_will_be_visible=,
 -2-male_small_crotch_is_visible=horny,Das ist sicherlich so süß!
+-2-male_small_crotch_is_visible=horny,Mind if I take a closer look?
 -2-male_medium_crotch_is_visible=horny,Verdammt, das ist so geil!
 -2-male_large_crotch_is_visible=shocked,Unglaublich! Just looking at that is boosting me up!
 

--- a/opponents/mercy/behaviour.txt
+++ b/opponents/mercy/behaviour.txt
@@ -235,12 +235,12 @@ female_must_strip=interested,Pech ~name~, rules are rules.
 -3-male_human_must_strip=happy,Vielen Dank ~name~, better you then me at this point!
 -3-male_must_strip=embarrassed,Am I distracting you? Because that would be great for me.
 -3-male_must_strip=happy,Vielen Dank ~name~, better you then me at this point!
--3-female_human_must_strip=embarrassed,Atleast you diverted the attention for a while...
+-3-female_human_must_strip=embarrassed,At least you diverted the attention for a while...
 -3-female_must_strip=happy,Suddenly the staring has decreased, atleast for a bit.
 
 #masturbating
 -2-male_human_must_strip=horny,Yes ~name~...Give me a boost...
--2-male_human_must_strip=horny,...Ah ~name~....I could use a buff...
+-2-male_human_must_strip=horny,...Ah ~name~.... I could use a buff...
 -2-male_must_strip=horny,Yes ~name~...Give me a boost...
 -2-female_human_must_strip=horny,..Ah..Ah...Take it off...
 -2-female_must_strip=horny,...Yes ~name~, this will aid me....
@@ -264,7 +264,7 @@ female_removed_accessory=calm,No to worry ~name~, I would have done the same.
 
 #fully clothed
 0-male_removing_accessory=calm,Smart move ~name~, the turtle wins the race.
-0-male_removed_accessory=calm,Atleast you can't use your ~clothing~ anymore.
+0-male_removed_accessory=calm,At least you can't use your ~clothing~ anymore.
 0-female_removing_accessory=calm,Rome wasen't build in a day.
 0-female_removed_accessory=calm,Your ~clothing~ won't protect you next time!
 
@@ -287,9 +287,9 @@ female_removed_accessory=calm,No to worry ~name~, I would have done the same.
 #lost 3 items
 3-male_removing_accessory=calm,Look at it this way ~name~, now I get to keep my stockings on.
 3-male_removing_accessory=sad,Surely you can do better, ~name~!
-3-male_removed_accessory=calm,Atleast that is out of the way now.
+3-male_removed_accessory=calm,At least that is out of the way now.
 3-female_removing_accessory=calm,Look at it this way ~name~, now I get to keep my stockings on.
-3-female_removed_accessory=calm,Atleast that is out of the way now.
+3-female_removed_accessory=calm,At least that is out of the way now.
 
 #lost 4 items
 4-male_removing_accessory=sad,Only your ~clothing~? That isn't very healthy.
@@ -306,13 +306,13 @@ female_removed_accessory=calm,No to worry ~name~, I would have done the same.
 
 
 #nude
--3-male_removing_accessory=sad,You still have ~clothing~ while i'm fully naked?
+-3-male_removing_accessory=sad,You still have ~clothing~ while I'm fully naked?
 -3-male_removing_accessory=sad,I see you came prepared...
 -3-male_removing_accessory=embarrassed,I see you staring ~name~, now off with your ~clothing~.
 -3-male_removed_accessory=embarrassed,Maybe you could lend me your ~clothing~?
 -3-male_removed_accessory=sad,It seems I am not very good at this game...
 -3-female_removing_accessory=sad,I was ill equipped it seems.
--3-female_removing_accessory=embarrassed,Atleast you still had your ~clothing~, ~name~.
+-3-female_removing_accessory=embarrassed,At least you still had your ~clothing~, ~name~.
 -3-female_removing_accessory=embarrassed,I see you staring ~name~, now off with your ~clothing~.
 -3-female_removed_accessory=sad,Take of some more clothing next time, ~name~. Doctor's orders.
 -3-female_removed_accessory=embarrassed,Maybe I should have supported you after all.
@@ -338,21 +338,21 @@ female_removed_accessory=calm,No to worry ~name~, I would have done the same.
 ##another character is removing minor clothing items
 
 male_removing_minor=calm,So ist das Leben, ~name~.
-male_removing_minor=calm,The prognosis for your ~clothing~ isn't good i'm afraid.
+male_removing_minor=calm,The prognosis for your ~clothing~ isn't good I'm afraid.
 male_removed_minor=happy,One step closer to a full body "examination".
-female_removing_minor=calm,The prognosis for your ~clothing~ isn't good i'm afraid.
+female_removing_minor=calm,The prognosis for your ~clothing~ isn't good I'm afraid.
 female_removing_minor=calm,Your guardian angel must have flown away...
 female_removed_minor=happy,A glimpse of what is to come!
 female_removed_minor=happy,One small step for ~name~,one giant leap for us!
 
 #fully clothed
-0-male_removing_minor=interested,The prognosis for your ~clothing~ isn't good i'm afraid.
+0-male_removing_minor=interested,The prognosis for your ~clothing~ isn't good I'm afraid.
 0-male_removing_minor=interested,I would help ~name~, but rules are rules.
-0-male_removed_minor=happy,Don't be scared to show your doctor some skin ~name~.
+0-male_removed_minor=happy,Don't be scared to show your doctor some skin, ~name~.
 0-male_removed_minor=interested,Excellent, keep this up and you might get a lollipop.
-0-female_removing_minor=interested,The prognosis for your ~clothing~ isn't good i'm afraid.
+0-female_removing_minor=interested,The prognosis for your ~clothing~ isn't good I'm afraid.
 0-female_removing_minor=interested,One step at a time.
-0-female_removed_minor=calm,Atleast that is out of the way now.
+0-female_removed_minor=calm,At least that is out of the way now.
 0-female_removed_minor=calm,Perhaps something bigger next time?
 #lost 1 item
 1-male_removing_minor=happy,Off with your ~clothes~!
@@ -375,7 +375,7 @@ female_removed_minor=happy,One small step for ~name~,one giant leap for us!
 
 #lost 4 items
 4-male_removing_minor=embarassed,Even while stripping you still stare.
-4-male_removed_minor=calm,Atleast you still had your ~clothes~.
+4-male_removed_minor=calm,At least you still had your ~clothes~.
 4-female_removing_minor=embarassed,Taking of your ~clothes~? Wish I could still do the same...
 4-female_removed_minor=calm,Acceptable, for now.
 
@@ -441,7 +441,7 @@ female_removed_major=interested,The human body truly is a wonder.
 #lost 4 items
 4-male_removing_major=interested,Seems like our luck has ran out, ~name~.
 4-male_removed_major=embarrassed,You wanted it to be me didn't you, ~name~?
-4-female_removing_major=interested,Hope you enjoy getting stared at ~name~, because i'm beginning to.
+4-female_removing_major=interested,Hope you enjoy getting stared at ~name~, because I'm beginning to.
 4-female_removed_major=embarrassed,It seems to be getting hot in here or is that just me?
 
 #lost 5 items
@@ -477,7 +477,7 @@ male_chest_is_visible=interested,Wow ~name~, you seem to be in good shape.
 male_crotch_will_be_visible=horny,You seem swollen down there ~name~, might wanna show that to a doctor...
 male_small_crotch_is_visible=horny,Mind if I take a closer look?
 male_medium_crotch_is_visible=horny,Wunderbar...
-male_large_crotch_is_visible=shocked,Fascinating...It seems to be twitching, mind if I take a look?
+male_large_crotch_is_visible=shocked,Fascinating... It seems to be twitching, mind if I take a look?
 female_chest_will_be_visible=interested,All eyes on you ~name~.
 female_small_chest_is_visible=interested,Not too big but they have the perfect shape...
 female_medium_chest_is_visible=horny,Your nipples seem to have gotten hard, want me to cure them?
@@ -489,12 +489,12 @@ female_crotch_is_visible=shocked,It is kind off hard to see from here, perhaps l
 0-male_chest_will_be_visible=happy,Don't keep the doctor waiting.
 0-male_chest_is_visible=horny,You seem to be in good shape.
 0-male_crotch_will_be_visible=horny,You seem swollen down there ~name~, might wanna show that to a doctor...
-0-male_small_crotch_is_visible=horny,Not to big but oddly captivating...
+0-male_small_crotch_is_visible=horny,Not too big but oddly captivating...
 0-male_medium_crotch_is_visible=horny,I've never seen one so stiff before...
 0-male_large_crotch_is_visible=shocked,The size reminds me of my Caduceus Staff...
 
 0-female_chest_will_be_visible=happy,Don't be shy, a healthy body should be shown!
-0-female_small_chest_is_visible=horny,The perfect size to be fondled...I-I mean examined...
+0-female_small_chest_is_visible=horny,The perfect size to be fondled... I-I mean examined...
 0-female_medium_chest_is_visible=horny,Such stellar examples of a healthy body...
 0-female_large_chest_is_visible=horny,Large breasts aren't always the cause of back pain, but those look very heavy...
 0-female_crotch_will_be_visible=horny,Why am I getting exicted over this...
@@ -520,7 +520,7 @@ female_crotch_is_visible=shocked,It is kind off hard to see from here, perhaps l
 2-male_chest_is_visible=,
 2-male_crotch_will_be_visible=horny,You seem swollen down there ~name~, might wanna show that to a doctor...
 2-male_small_crotch_is_visible=,
-2-male_medium_crotch_is_visible=horny,Whoa!...It looks hard. As a doctor I'd be happy to lessen the "pain".
+2-male_medium_crotch_is_visible=horny,Whoa!... It looks hard. As a doctor I'd be happy to lessen the "pain".
 2-male_large_crotch_is_visible=horny,Does that payload need any protecting?
 
 2-female_chest_will_be_visible=,
@@ -581,7 +581,7 @@ female_crotch_is_visible=shocked,It is kind off hard to see from here, perhaps l
 -3-male_crotch_will_be_visible=horny,You seem swollen down there ~name~, was it my doing?
 -3-male_small_crotch_is_visible=horny,It's kind of small but yet it still draws me in.
 -3-male_medium_crotch_is_visible=horny,Verdammt, I should be professional but that looks like a great place to take a seat...
--3-male_medium_crotch_is_visible=horny,Whoa...It's been a while since I saw one, I wanna take a picture...for science...
+-3-male_medium_crotch_is_visible=horny,Whoa... It's been a while since I saw one, I wanna take a picture...for science...
 -3-male_large_crotch_is_visible=shocked,Verdammt, I should be professional but that size makes me want to drool...
 -3-male_large_crotch_is_visible=shocked,Whoa...~name~, I've never seen such a big example before, is it because you were looking at me all nude?
 
@@ -669,7 +669,7 @@ female_finished_masturbating=shocked,Wow, that was quite... I would love to do s
 -1-male_finished_masturbating=Wow! That is quite a big load. You must have been dying for a release. It's not healthy to keep it all in like that.
 
 -1-female_must_masturbate=interested,Well I did it, ~name~. So it's only fair if you go to. Doctor's orders.
--1-female_start_masturbating=horny,Just follow my example, trust me...I'm a doctor.
+-1-female_start_masturbating=horny,Just follow my example, trust me... I'm a doctor.
 -1-female_start_masturbating=horny,I see you already got wet over my performance.
 -1-female_masturbating=horny,Yes, just like that. Keep up a good rythm.
 -1-female_masturbating=horny,I would help you out, if the rules would allow me. Maybe next time!

--- a/opponents/mercy/behaviour.txt
+++ b/opponents/mercy/behaviour.txt
@@ -597,7 +597,6 @@ female_crotch_is_visible=shocked,It is kind off hard to see from here, perhaps l
 -2-male_chest_is_visible=,
 -2-male_crotch_will_be_visible=,
 -2-male_small_crotch_is_visible=horny,Das ist sicherlich so süß!
--2-male_small_crotch_is_visible=horny,Mind if I take a closer look?
 -2-male_medium_crotch_is_visible=horny,Verdammt, das ist so geil!
 -2-male_large_crotch_is_visible=shocked,Unglaublich! Just looking at that is boosting me up!
 

--- a/opponents/mercy/behaviour.xml
+++ b/opponents/mercy/behaviour.xml
@@ -37,7 +37,7 @@
                 <state img="0-happy.png">Don't keep the doctor waiting.</state>
             </case>
             <case tag="female_removing_minor">
-                <state img="0-interested.png">The prognosis for your ~clothing~ isn't good i'm afraid.</state>
+                <state img="0-interested.png">The prognosis for your ~clothing~ isn't good I'm afraid.</state>
                 <state img="0-interested.png">One step at a time.</state>
             </case>
             <case tag="male_medium_crotch_is_visible">
@@ -53,11 +53,11 @@
                 <state img="0-horny.png">Why am I getting exicted over this...</state>
             </case>
             <case tag="male_removed_minor">
-                <state img="0-happy.png">Don't be scared to show your doctor some skin ~name~.</state>
+                <state img="0-happy.png">Don't be scared to show your doctor some skin, ~name~.</state>
                 <state img="0-interested.png">Excellent, keep this up and you might get a lollipop.</state>
             </case>
             <case tag="male_removed_accessory">
-                <state img="0-calm.png">Atleast you can't use your ~clothing~ anymore.</state>
+                <state img="0-calm.png">At least you can't use your ~clothing~ anymore.</state>
             </case>
             <case tag="male_must_masturbate">
                 <state img="0-interested.png">Don't worry, it's totally natural to satisfy your sexual desires yourself.</state>
@@ -105,7 +105,7 @@
                 <state img="0-interested.png">Ah ~name~, I wonder what clothing you will remove.</state>
             </case>
             <case tag="male_small_crotch_is_visible">
-                <state img="0-horny.png">Not to big but oddly captivating...</state>
+                <state img="0-horny.png">Not too big but oddly captivating...</state>
             </case>
             <case tag="male_removing_accessory">
                 <state img="0-calm.png">Smart move ~name~, the turtle wins the race.</state>
@@ -114,7 +114,7 @@
                 <state img="0-shocked.png">Wow, looks like you have been keeping it in for a while...</state>
             </case>
             <case tag="female_small_chest_is_visible">
-                <state img="0-horny.png">The perfect size to be fondled...I-I mean examined...</state>
+                <state img="0-horny.png">The perfect size to be fondled... I-I mean examined...</state>
             </case>
             <case tag="female_medium_chest_is_visible">
                 <state img="0-horny.png">Such stellar examples of a healthy body...</state>
@@ -129,7 +129,7 @@
                 <state img="0-interested.png"> You should hold nothing back from your doctor...</state>
             </case>
             <case tag="male_removing_minor">
-                <state img="0-interested.png">The prognosis for your ~clothing~ isn't good i'm afraid.</state>
+                <state img="0-interested.png">The prognosis for your ~clothing~ isn't good I'm afraid.</state>
                 <state img="0-interested.png">I would help ~name~, but rules are rules.</state>
             </case>
             <case tag="female_finished_masturbating">
@@ -142,7 +142,7 @@
                 <state img="0-horny.png">I see you perfected this way of stimulating yourself.</state>
             </case>
             <case tag="female_removed_minor">
-                <state img="0-calm.png">Atleast that is out of the way now.</state>
+                <state img="0-calm.png">At least that is out of the way now.</state>
                 <state img="0-calm.png">Perhaps something bigger next time?</state>
             </case>
             <case tag="male_crotch_will_be_visible">
@@ -372,7 +372,7 @@
                 <state img="2-happy.png">Don't keep the doctor waiting ~name~.</state>
             </case>
             <case tag="male_medium_crotch_is_visible">
-                <state img="2-horny.png">Whoa!...It looks hard. As a doctor I'd be happy to lessen the "pain".</state>
+                <state img="2-horny.png">Whoa!... It looks hard. As a doctor I'd be happy to lessen the "pain".</state>
             </case>
             <case tag="female_removed_major">
                 <state img="2-happy.png">Super! You look great ~name~.</state>
@@ -544,7 +544,7 @@
                 <state img="3-happy.png">How cute you seem to be blushing ~name~.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="3-shocked.png">Fascinating...It seems to be twitching, mind if I take a look?</state>
+                <state img="3-shocked.png">Fascinating... It seems to be twitching, mind if I take a look?</state>
             </case>
             <case tag="female_crotch_will_be_visible">
                 <state img="3-horny.png">Show the doctor what you got ~name~...</state>
@@ -553,7 +553,7 @@
                 <state img="3-calm.png">On to the next round.</state>
             </case>
             <case tag="male_removed_accessory">
-                <state img="3-calm.png">Atleast that is out of the way now.</state>
+                <state img="3-calm.png">At least that is out of the way now.</state>
             </case>
             <case tag="male_must_masturbate">
                 <state img="3-interested.png">Don't worry, it's totally natural to satisfy your sexual desires yourself.</state>
@@ -574,7 +574,7 @@
                 <state img="3-interested.png">This should be promising.</state>
             </case>
             <case tag="female_removed_accessory">
-                <state img="3-calm.png">Atleast that is out of the way now.</state>
+                <state img="3-calm.png">At least that is out of the way now.</state>
             </case>
             <case tag="male_removed_major">
                 <state img="3-happy.png">If it makes you feel better I lost my armor to.</state>
@@ -707,13 +707,13 @@
                 <state img="4-embarrassed.png">It seems to be getting hot in here or is that just me?</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="4-shocked.png">Fascinating...It seems to be twitching, mind if I take a look?</state>
+                <state img="4-shocked.png">Fascinating... It seems to be twitching, mind if I take a look?</state>
             </case>
             <case tag="female_crotch_will_be_visible">
                 <state img="4-horny.png">Show the doctor what you got ~name~...</state>
             </case>
             <case tag="male_removed_minor">
-                <state img="4-calm.png">Atleast you still had your ~clothes~.</state>
+                <state img="4-calm.png">At least you still had your ~clothes~.</state>
             </case>
             <case tag="male_removed_accessory">
                 <state img="4-interested.png">Let's see if you can do better next time.</state>
@@ -786,7 +786,7 @@
                 <state img="4-happy.png">You might not want to tell your friends about that.</state>
             </case>
             <case tag="female_removing_major">
-                <state img="4-interested.png">Hope you enjoy getting stared at ~name~, because i'm beginning to.</state>
+                <state img="4-interested.png">Hope you enjoy getting stared at ~name~, because I'm beginning to.</state>
             </case>
             <case tag="male_removing_minor">
                 <state img="4-embarassed.png">Even while stripping you still stare.</state>
@@ -1022,7 +1022,7 @@
             </case>
             <case tag="male_medium_crotch_is_visible">
                 <state img="6-horny.png">Verdammt, I should be professional but that looks like a great place to take a seat...</state>
-                <state img="6-horny.png">Whoa...It's been a while since I saw one, I wanna take a picture...for science...</state>
+                <state img="6-horny.png">Whoa... It's been a while since I saw one, I wanna take a picture...for science...</state>
             </case>
             <case tag="female_removed_major">
                 <state img="6-horny.png">Your body betrays your "excitement"...</state>
@@ -1048,7 +1048,7 @@
                 <state img="6-horny.png">There have been studies that prove the existence of the G-Spot, did you find it yet?</state>
             </case>
             <case tag="female_human_must_strip">
-                <state img="6-embarrassed.png">Atleast you diverted the attention for a while...</state>
+                <state img="6-embarrassed.png">At least you diverted the attention for a while...</state>
             </case>
             <case tag="female_crotch_is_visible">
                 <state img="6-horny.png">Epic!</state>
@@ -1090,7 +1090,7 @@
                 <state img="6-horny.png">It's kind of small but yet it still draws me in.</state>
             </case>
             <case tag="male_removing_accessory">
-                <state img="6-sad.png">You still have ~clothing~ while i'm fully naked?</state>
+                <state img="6-sad.png">You still have ~clothing~ while I'm fully naked?</state>
                 <state img="6-sad.png">I see you came prepared...</state>
                 <state img="6-embarrassed.png">I see you staring ~name~, now off with your ~clothing~.</state>
             </case>
@@ -1105,7 +1105,7 @@
             </case>
             <case tag="female_removing_accessory">
                 <state img="6-sad.png">I was ill equipped it seems.</state>
-                <state img="6-embarrassed.png">Atleast you still had your ~clothing~, ~name~.</state>
+                <state img="6-embarrassed.png">At least you still had your ~clothing~, ~name~.</state>
                 <state img="6-embarrassed.png">I see you staring ~name~, now off with your ~clothing~.</state>
             </case>
             <case tag="game_over_victory">
@@ -1184,9 +1184,6 @@
             <case tag="female_removing_minor">
                 <state img="7-horny.png">This should boost my performance...</state>
             </case>
-			<case tag="male_small_crotch_is_visible">
-                <state img="7-horny.png">Das ist sicherlich so süß!</state>
-            </case>
             <case tag="male_medium_crotch_is_visible">
                 <state img="7-horny.png">Verdammt, das ist so geil!</state>
             </case>
@@ -1248,9 +1245,10 @@
             </case>
             <case tag="male_human_must_strip">
                 <state img="7-horny.png">Yes ~name~...Give me a boost...</state>
-                <state img="7-horny.png">...Ah ~name~....I could use a buff...</state>
+                <state img="7-horny.png">...Ah ~name~.... I could use a buff...</state>
             </case>
             <case tag="male_small_crotch_is_visible">
+                <state img="7-horny.png">Das ist sicherlich so s&#252;&#223;!</state>
                 <state img="7-horny.png">Mind if I take a closer look?</state>
             </case>
             <case tag="male_removing_accessory">
@@ -1327,7 +1325,7 @@
                 <state img="8-happy.png">This is starting to make me excited again.</state>
             </case>
             <case tag="male_large_crotch_is_visible">
-                <state img="8-shocked.png">Fascinating...It seems to be twitching, mind if I take a look?</state>
+                <state img="8-shocked.png">Fascinating... It seems to be twitching, mind if I take a look?</state>
             </case>
             <case tag="female_crotch_will_be_visible">
                 <state img="8-horny.png">Show the doctor what you got ~name~...</state>
@@ -1353,7 +1351,7 @@
                 <state img="8-shocked.png">It is kind off hard to see from here, perhaps lend your doctor a closer look? Please...</state>
             </case>
             <case tag="female_start_masturbating">
-                <state img="8-horny.png">Just follow my example, trust me...I'm a doctor.</state>
+                <state img="8-horny.png">Just follow my example, trust me... I'm a doctor.</state>
                 <state img="8-horny.png">I see you already got wet over my performance.</state>
             </case>
             <case tag="male_removing_major">


### PR DESCRIPTION
Fixes this bug: https://www.reddit.com/r/spnati/comments/5pe0xo/v12_game_flow_and_general_discussionquestions/dcrg10u/

Long story short, fixes were made to the xml file directly, and those changes were lost when make_xml.py was run on the behaviour.txt file the next time. I have added the xml changes to the txt file along with some other small typo fixes.

The change I made to make_xml.py looks weird (  \<state img="7-horny.png">Das ist sicherlich so s&#252;&#223;!\</state> whaaat?), but I checked to make sure it works:

![image](https://cloud.githubusercontent.com/assets/25289343/22192466/46bbde1c-e0e9-11e6-992f-a0369879661a.png)

